### PR TITLE
update example to work with more recent versions of forcelayout and p…

### DIFF
--- a/examples/pixi.js/04 - Individual Node Events/index.js
+++ b/examples/pixi.js/04 - Individual Node Events/index.js
@@ -19,14 +19,13 @@ module.exports.main = function () {
 }
 
 function createLayout(graph) {
-  var layout = require('ngraph.forcelayout'),
-      physics = require('ngraph.physics.simulator');
+  var layout = require('ngraph.forcelayout');
 
-  return layout(graph, physics({
+  return layout(graph, {
           springLength: 30,
           springCoeff: 0.0008,
           dragCoeff: 0.01,
           gravity: -1.2,
           theta: 1
-        }));
+        });
 }


### PR DESCRIPTION
When using the original code with the more recent versions of forcelayout and physics.simulator I found that 1) there was a javascript error being thrown from interaction with ngraph.event and 2) the physics parameters I had specified were being ignored. The proposed changes seem to fix both of these issues.

As a new user of ngraph I naturally look to the example code for my own starting point, thus I think it would be generally helpful to the community of users to update the example code to work with the most recent versions of other ngraph components.

Thanks!  ~ry