### PR TITLE
Updated browserify version

### DIFF
--- a/examples/three.js/Basic/package.json
+++ b/examples/three.js/Basic/package.json
@@ -8,7 +8,7 @@
     "query-string": "~0.1.1"
   },
   "devDependencies": {
-    "browserify": "~3.18.0",
+    "browserify": "~12.0.0",
     "uglify-js": "^2.4.13"
   }
 }

--- a/examples/three.js/Dynamic/package.json
+++ b/examples/three.js/Dynamic/package.json
@@ -9,7 +9,7 @@
     "ngraph.graph": "0.0.4"
   },
   "devDependencies": {
-    "browserify": "~3.18.0",
+    "browserify": "~12.0.0",
     "uglify-js": "^2.4.13"
   }
 }

--- a/examples/three.js/Side by side/package.json
+++ b/examples/three.js/Side by side/package.json
@@ -8,7 +8,7 @@
     "ngraph.fabric": "0.0.1"
   },
   "devDependencies": {
-    "browserify": "~3.18.0",
+    "browserify": "~12.0.0",
     "uglify-js": "^2.4.13"
   }
 }

--- a/examples/three.js/UFL/package.json
+++ b/examples/three.js/UFL/package.json
@@ -9,7 +9,7 @@
     "ngraph.serialization": "0.0.3"
   },
   "devDependencies": {
-    "browserify": "~3.18.0",
+    "browserify": "~12.0.0",
     "uglify-js": "^2.4.13"
   }
 }


### PR DESCRIPTION
Old browserify was complaining about missing `esprima-six` this make examples work again.

Thanks for the great work!